### PR TITLE
Temporary workaround to support bottom dashtodock.

### DIFF
--- a/workspaces-to-dock@passingthru67.gmail.com/dockedWorkspaces.js
+++ b/workspaces-to-dock@passingthru67.gmail.com/dockedWorkspaces.js
@@ -370,7 +370,9 @@ const DockedWorkspaces = new Lang.Class({
                         dashMonitorIndex = this._primaryIndex;
                     }
                     if (i == dashMonitorIndex) {
-                        dashWidth = DashToDock.dock._box.width + spacing;
+                        if( DashToDock.dock._settings.get_enum('dock-position') == St.Side.LEFT ||
+                            DashToDock.dock._settings.get_enum('dock-position') == St.Side.RIGHT )
+                                dashWidth = DashToDock.dock._box.width + spacing;
                     }
                 } else {
                     if (i == this._primaryIndex) {


### PR DESCRIPTION
Do not consider dash width when it's placed on the bottom edge of the screen.

This refer to this bug:
https://github.com/micheleg/dash-to-dock/issues/130

This is just a possible workaround. I'm also wondering if using a spacer actor as the upstream code and now also dashtodock does would suite your extension instead of manually tweaking the overview size.

