### PR TITLE
Remove fullheight borders

### DIFF
--- a/workspaces-to-dock@passingthru67.gmail.com/themes/default/workspaces-to-dock.css
+++ b/workspaces-to-dock@passingthru67.gmail.com/themes/default/workspaces-to-dock.css
@@ -52,18 +52,26 @@
 
 #workspacestodockDock.right.fullheight .workspace-thumbnails {
     border-radius: 0px;
+    border-top-width: 0px;
+    border-bottom-width: 0px;
 }
 
 #workspacestodockDock.left.fullheight .workspace-thumbnails {
     border-radius: 0px;
+    border-top-width: 0px;
+    border-bottom-width: 0px;
 }
 
 #workspacestodockDock.top.fullheight .workspace-thumbnails {
     border-radius: 0px;
+    border-left-width: 0px;
+    border-right-width: 0px;
 }
 
 #workspacestodockDock.bottom.fullheight .workspace-thumbnails {
     border-radius: 0px;
+    border-left-width: 0px;
+    border-right-width: 0px;
 }
 
 #workspacestodockDock.right .workspacestodock-shortcuts-panel {


### PR DESCRIPTION
To make the full height setting slightly nicer looking.  This removes the top and bottom borders for left/right positions, and right and left borders for top/bottom positions.