### PR TITLE
Adapt left right workspace switcher styles to use -left and -right style with a "fallback" to -up and -down

### DIFF
--- a/workspaces-to-dock@passingthru67.gmail.com/myWorkspaceSwitcherPopup.js
+++ b/workspaces-to-dock@passingthru67.gmail.com/myWorkspaceSwitcherPopup.js
@@ -130,9 +130,9 @@ var myWorkspaceSwitcherPopup = new Lang.Class({
             let indicator = null;
 
            if (i == this._activeWorkspaceIndex && this._direction == Meta.MotionDirection.LEFT)
-               indicator = new St.Bin({ style_class: 'ws-switcher-active-up' });
+               indicator = new St.Bin({ style_class: 'ws-switcher-active-up ws-switcher-active-left' });
            else if (i == this._activeWorkspaceIndex && this._direction == Meta.MotionDirection.RIGHT)
-               indicator = new St.Bin({ style_class: 'ws-switcher-active-down' });
+               indicator = new St.Bin({ style_class: 'ws-switcher-active-down ws-switcher-active-right' });
            else if (i == this._activeWorkspaceIndex && this._direction == Meta.MotionDirection.UP)
                indicator = new St.Bin({ style_class: 'ws-switcher-active-up' });
            else if(i == this._activeWorkspaceIndex && this._direction == Meta.MotionDirection.DOWN)


### PR DESCRIPTION
Currently the `ws-switcher-active-up` and `ws-switcher-active-down` styles are used for left and right works space switching since most themes support only up and down. For some themes, that use visual cues of arrows that creates odd user experience, as shown below.

![workspace-switcher-up](https://user-images.githubusercontent.com/582074/46260916-44ed9600-c4a1-11e8-8780-cc58870065e8.png)
![workspace-switcher-down](https://user-images.githubusercontent.com/582074/46260918-4dde6780-c4a1-11e8-929a-8b0d00aaa3ce.png)

The PR contains a fix of applying "-up" or "-down" style followed by "-left" or "-rigth" styles to allow themes that have that style to apply -left and -right (though th styles will have to do overrides to remove anything applies by -up or -down). This seems like a reasonable compromise for now and provides a good user experience.
![workspace-switcher-left](https://user-images.githubusercontent.com/582074/46261007-89c5fc80-c4a2-11e8-9aa7-c11e7c23dc8d.png)
![workspace-switcher-right](https://user-images.githubusercontent.com/582074/46261009-8e8ab080-c4a2-11e8-91c5-6a035cf0b735.png)

If this fix is too hacky I can update the PR for couple of other possibilities, for example I can try to see if existence of css style name for "-left" and "-right" can be looked up and applied or alternatively add a preference option to use the "-left"/"-right" style if the user chooses so (which seems and overkill).

Please accept the PR or advise on the approach.