### PR TITLE
Fix errors for Gnome 3.34 (WIP)

### DIFF
--- a/workspaces-to-dock@passingthru67.gmail.com/dockedWorkspaces.js
+++ b/workspaces-to-dock@passingthru67.gmail.com/dockedWorkspaces.js
@@ -489,7 +489,7 @@ var DockedWorkspaces = class WorkspacesToDock_DockedWorkspaces {
                 this._onIconsChanged.bind(this)
             ],
             [
-                ExtensionSystem._signals,
+                Main.extensionManager,
                 'extension-state-changed',
                 this._onExtensionSystemStateChanged.bind(this)
             ],
@@ -522,7 +522,7 @@ var DockedWorkspaces = class WorkspacesToDock_DockedWorkspaces {
 
         // Connect DashToDock hover signal if the extension is already loaded and enabled
         this._hoveringDash = false;
-        DashToDockExtension = ExtensionUtils.extensions[DashToDock_UUID];
+        DashToDockExtension = Main.extensionManager.lookup(DashToDock_UUID);
         if (DashToDockExtension) {
             if (DashToDockExtension.state == ExtensionSystem.ExtensionState.ENABLED) {
                 if (_DEBUG_) global.log("dockeWorkspaces: init - DashToDock extension is installed and enabled");

--- a/workspaces-to-dock@passingthru67.gmail.com/myWorkspaceThumbnail.js
+++ b/workspaces-to-dock@passingthru67.gmail.com/myWorkspaceThumbnail.js
@@ -760,9 +760,6 @@ class WorkspacesToDock_MyThumbnailsBox extends St.Widget {
                           request_mode: Clutter.RequestMode.WIDTH_FOR_HEIGHT });
         }
 
-        this.actor = this;
-        this.actor._delegate = this;
-
         // Add addtional style class when workspace is fixed and set to full height
         if (this._mySettings.get_boolean('customize-height') && this._mySettings.get_int('customize-height-option') == 1) {
             if (this._mySettings.get_double('top-margin') == 0 || this._mySettings.get_double('bottom-margin') == 0) {
@@ -916,7 +913,6 @@ class WorkspacesToDock_MyThumbnailsBox extends St.Widget {
         // Destroy thumbnails
         this._destroyThumbnails();
 
-        this.actor = null;
         this._indicator = null;
 
         if (_DEBUG_) global.log("myWorkspaceThumbnail: dispose settings");

--- a/workspaces-to-dock@passingthru67.gmail.com/shortcutsPanel.js
+++ b/workspaces-to-dock@passingthru67.gmail.com/shortcutsPanel.js
@@ -318,7 +318,7 @@ var ShortcutButton = class WorkspacesToDock_ShortcutButton {
         this._iconContainer.add_child(this._icon.actor);
 
         this._menu = null;
-        this._menuManager = new PopupMenu.PopupMenuManager(this);
+        this._menuManager = new PopupMenu.PopupMenuManager(this.actor);
         this._menuTimeoutId = 0;
 
         // Connect button signals

--- a/workspaces-to-dock@passingthru67.gmail.com/thumbnailCaption.js
+++ b/workspaces-to-dock@passingthru67.gmail.com/thumbnailCaption.js
@@ -335,7 +335,7 @@ var ThumbnailCaption = class WorkspacesToDock_ThumbnailCaption {
             global.window_manager.connect('switch-workspace',
                                           this.activeWorkspaceChanged.bind(this));
 
-        this._menuManager = new PopupMenu.PopupMenuManager(this);
+        this._menuManager = new PopupMenu.PopupMenuManager(this.actor);
 
         this._initCaption();
         this._thumbnailRealizeId = this._thumbnail.actor.connect("realize", this._initTaskbar.bind(this));


### PR DESCRIPTION
Remove all the runtime errors for Gnome 3.34 but have some glitch and deprecated API references.

- Deprecated API
`Usage of object.actor is deprecated for *` is printed because of [this](https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/487/diffs)

- glitches
  - scrolling over thumbnail is not working
  - when dock is rising by mouse, the whole dock is shaking