### PR TITLE
Enforce integer label position to avoid half pixel blur

### DIFF
--- a/workspaces-to-dock@passingthru67.gmail.com/thumbnailCaption.js
+++ b/workspaces-to-dock@passingthru67.gmail.com/thumbnailCaption.js
@@ -176,7 +176,7 @@ var TaskbarIcon = class WorkspacesToDock_TaskbarIcon {
         let [buttonStageX, buttonStageY] = this.actor.get_transformed_position();
         let labelWidth = this.tooltip.get_width();
         let buttonWidth = this.actor.get_width();
-        let x = buttonStageX + (buttonWidth / 2) - (labelWidth / 2);
+        let x = Math.floor(buttonStageX + (buttonWidth - labelWidth) / 2);
         let labelHeight = this.tooltip.get_height();
         let y = buttonStageY - labelHeight;
 


### PR DESCRIPTION
Before / After

![pixel-alignment-before-after](https://user-images.githubusercontent.com/553906/89107134-e5de6c80-d3fc-11ea-9d98-be0b8fe1b8da.png)
